### PR TITLE
Improve mod correctness and side-safety

### DIFF
--- a/src/main/java/com/solegendary/reignofnether/CommonModEvents.java
+++ b/src/main/java/com/solegendary/reignofnether/CommonModEvents.java
@@ -118,7 +118,7 @@ public class CommonModEvents {
         evt.put(EntityRegistrar.GRIZZLY_BEAR_UNIT.get(), GrizzlyBearUnit.createAttributes().build());
         evt.put(EntityRegistrar.PANDA_UNIT.get(), PandaUnit.createAttributes().build());
         evt.put(EntityRegistrar.WOLF_UNIT.get(), WolfUnit.createAttributes().build());
-        evt.put(EntityRegistrar.LLAMA_UNIT.get(), WolfUnit.createAttributes().build());
+        evt.put(EntityRegistrar.LLAMA_UNIT.get(), LlamaUnit.createAttributes().build());
         evt.put(EntityRegistrar.PHANTOM_SUMMON.get(), PhantomSummon.createAttributes().build());
 
         evt.put(EntityRegistrar.ZOMBIE_UNIT.get(), ZombieUnit.createAttributes().build());
@@ -176,17 +176,17 @@ public class CommonModEvents {
 
     @SubscribeEvent
     public static void creativeTabSetup(BuildCreativeModeTabContentsEvent event) {
-        if(BuiltInRegistries.CREATIVE_MODE_TAB.getKey(event.getTab())==CreativeModeTabs.BUILDING_BLOCKS.location()){
+        if(BuiltInRegistries.CREATIVE_MODE_TAB.getKey(event.getTab()).equals(CreativeModeTabs.BUILDING_BLOCKS.location())){
             for(Item item : BlockRegistrar.blockItems.get(CreativeModeTabs.BUILDING_BLOCKS)){
                 event.accept(item);
             }
         }
-        if(BuiltInRegistries.CREATIVE_MODE_TAB.getKey(event.getTab())==CreativeModeTabs.FUNCTIONAL_BLOCKS.location()){
+        if(BuiltInRegistries.CREATIVE_MODE_TAB.getKey(event.getTab()).equals(CreativeModeTabs.FUNCTIONAL_BLOCKS.location())){
             for(Item item : BlockRegistrar.blockItems.get(CreativeModeTabs.FUNCTIONAL_BLOCKS)){
                 event.accept(item);
             }
         }
-        if(BuiltInRegistries.CREATIVE_MODE_TAB.getKey(event.getTab())==CreativeModeTabs.SPAWN_EGGS.location()){
+        if(BuiltInRegistries.CREATIVE_MODE_TAB.getKey(event.getTab()).equals(CreativeModeTabs.SPAWN_EGGS.location())){
             event.accept(ItemRegistrar.ZOMBIE_UNIT_SPAWN_EGG);
             event.accept(ItemRegistrar.HUSK_UNIT_SPAWN_EGG);
             event.accept(ItemRegistrar.DROWNED_UNIT_SPAWN_EGG);
@@ -227,7 +227,7 @@ public class CommonModEvents {
             event.accept(ItemRegistrar.GRIZZLY_BEAR_UNIT_SPAWN_EGG);
             event.accept(ItemRegistrar.POLAR_BEAR_UNIT_SPAWN_EGG);
         }
-        if(BuiltInRegistries.CREATIVE_MODE_TAB.getKey(event.getTab())==CreativeModeTabs.TOOLS_AND_UTILITIES.location()){
+        if(BuiltInRegistries.CREATIVE_MODE_TAB.getKey(event.getTab()).equals(CreativeModeTabs.TOOLS_AND_UTILITIES.location())){
             event.accept(ItemRegistrar.THROWABLE_TNT);
         }
     }

--- a/src/main/java/com/solegendary/reignofnether/ReignOfNether.java
+++ b/src/main/java/com/solegendary/reignofnether/ReignOfNether.java
@@ -68,8 +68,10 @@ public class ReignOfNether {
         Buildings.init();
         ProductionItems.init();
         MobEffectRegistrar.init();
-        final ClientEventRegistrar clientRegistrar = new ClientEventRegistrar();
-        DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> clientRegistrar::registerClientEvents);
+        DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> () -> {
+            final ClientEventRegistrar clientRegistrar = new ClientEventRegistrar();
+            clientRegistrar.registerClientEvents();
+        });
 
         final ServerEventRegistrar serverRegistrar = new ServerEventRegistrar();
         DistExecutor.safeRunWhenOn(Dist.DEDICATED_SERVER, () -> serverRegistrar::registerServerEvents);


### PR DESCRIPTION
Improve mod correctness and side-safety by fixing `ResourceLocation` comparisons, Llama entity attributes, and client-side class loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-e941decd-84e3-4c4c-bb16-9f8ba6b0a58d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e941decd-84e3-4c4c-bb16-9f8ba6b0a58d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>